### PR TITLE
Expose all interfaces with user-visible instances

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -585,7 +585,6 @@ will allow device manufacturers to support WebUSB on existing devices.
     required sequence&lt;USBDeviceFilter> filters;
   };
 
-  [NoInterfaceObject]
   interface USB : EventTarget {
     attribute EventHandler onconnect;
     attribute EventHandler ondisconnect;


### PR DESCRIPTION
Same way Web Bluetooth does, this would allow users to add helper functions to their prototypes without getting an object first.

Source: https://github.com/jyasskin/web-bluetooth-1/commit/240dc987cc824fef692c8a561b7ad8afe6fcef93

WDYT @reillyeon? 