### PR TITLE
Move deploy_key description into deploy.sh.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 language: generic
 sudo: false
 
-before_install:
-  - openssl aes-256-cbc -K $encrypted_2a342fc881c5_key -iv $encrypted_2a342fc881c5_iv -in deploy_key.enc -out deploy_key -d
-
 script: bash ./deploy.sh
 
 env:

--- a/deploy.sh
+++ b/deploy.sh
@@ -20,6 +20,7 @@ if [ "$TRAVIS_PULL_REQUEST" != "false" -o "$TRAVIS_BRANCH" != "$SOURCE_BRANCH" ]
 fi
 
 # Load the encrypted deploy key so we can push to $TARGET_BRANCH.
+openssl aes-256-cbc -K $encrypted_2a342fc881c5_key -iv $encrypted_2a342fc881c5_iv -in deploy_key.enc -out deploy_key -d
 chmod 600 deploy_key
 eval `ssh-agent -s`
 ssh-add deploy_key


### PR DESCRIPTION
This prevents the before_install step from failing on pull requests where the encrypted deploy key is not available.