### PR TITLE
Add a special value for a custom scheme

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -342,7 +342,14 @@ The <code>bScheme</code> field MUST be one of these values:
     <td>1</td>
     <td>"https://"</td>
   </tr>
+  <tr>
+    <td>255</td>
+    <td>""</td>
+  </tr>
 </table>
+
+The special value <code>255</code> indicates that the entire URL, including
+scheme, is encoded in the <code>URL</code> field.
 
 # Device Enumeration # {#enumeration}
 


### PR DESCRIPTION
The special value 255 for bScheme indicates that the full URL should be
present in the URL field, allowing custom schemes unknown to this
specification.

This resolves issue #43.