### PR TITLE
Add link to StackOverflow for developer support

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -11,6 +11,7 @@ Group: wicg
 Repository: https://github.com/WICG/webusb/
 !Participate: <a href="https://www.w3.org/community/wicg/">Join the W3C Community Group</a>
 !Participate: <a href="irc://irc.w3.org:6665/#webusb">IRC: #webusb on W3C's IRC</a> (Stay around for an answer, it make take a while)
+!Participate: <a href="http://stackoverflow.com/questions/tagged/webusb">Ask questions on StackOverflow</a>
 </pre>
 
 <style>


### PR DESCRIPTION
There is no appropriate mailing list for developers to get support using the API (as opposed to contributing to the specification process). The best place for this is StackOverflow so this patch adds a link to the "webusb" tag.

Resolves issue #80.