### PR TITLE
Add err argument to catch clause.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -482,7 +482,7 @@ subclass <code>0x01</code>,
           classCode: 0xFF, // vendor-specific
           protocolCode: 0x01
       }]});
-    } catch () {
+    } catch (err) {
       // No device was selected.
     }
 


### PR DESCRIPTION
The syntax otherwise is invalid javascript.