### PR TITLE
remove 'require' from USBPermissionStorage.allowedDevices, to correct WebIDL syntax (fixes #118)

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1562,7 +1562,7 @@ defined as follows:
       };
 
       dictionary USBPermissionStorage {
-        required sequence&lt;AllowedUSBDevice> allowedDevices = [];
+        sequence&lt;AllowedUSBDevice> allowedDevices = [];
       };
     </pre>
 


### PR DESCRIPTION
```
dictionary USBPermissionStorage {
  required sequence<AllowedUSBDevice> allowedDevices = [];
};
```

Isn't valid WebIDL syntax.  This patch removes the `required` directive.