### PR TITLE
Allow WebUSB to be used within a Web Worker

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -426,7 +426,7 @@ scheme, is encoded in the <code>URL</code> field.
     required sequence&lt;USBDeviceFilter> filters;
   };
 
-  [Exposed=(DedicatedWorker,SharedWorker,Window)]
+  [Exposed=(DedicatedWorker,SharedWorker,Window), SecureContext]
   interface USB : EventTarget {
     attribute EventHandler onconnect;
     attribute EventHandler ondisconnect;

--- a/index.bs
+++ b/index.bs
@@ -426,6 +426,7 @@ scheme, is encoded in the <code>URL</code> field.
     required sequence&lt;USBDeviceFilter> filters;
   };
 
+  [Exposed=(DedicatedWorker,SharedWorker,Window)]
   interface USB : EventTarget {
     attribute EventHandler onconnect;
     attribute EventHandler ondisconnect;
@@ -433,7 +434,7 @@ scheme, is encoded in the <code>URL</code> field.
     [Exposed=Window] Promise&lt;USBDevice> requestDevice(USBDeviceRequestOptions options);
   };
 
-  [SecureContext]
+  [Exposed=Window, SecureContext]
   partial interface Navigator {
     [SameObject] readonly attribute USB usb;
   };
@@ -1615,14 +1616,10 @@ defined as follows:
 ## Web Workers ## {#web-workers}
 
 The web [[workers]] API provides a method for running scripts in the background
-independently of user interface scripts. Web workers run scripts in their own
-separate worker context. Within this context, there is a {{WorkerNavigator}}
-interface that is analogous to the {{Navigator}} interface in the window
-context. Since web workers run scripts in the background, they should not be
-allowed to request a device.
+independently of user interface scripts.
 
 <pre class="idl">
-  [Exposed=Worker, SecureContext]
+  [Exposed=(DedicatedWorker,SharedWorker), SecureContext]
   partial interface WorkerNavigator {
     [SameObject] readonly attribute USB usb;
   };

--- a/index.bs
+++ b/index.bs
@@ -438,6 +438,11 @@ scheme, is encoded in the <code>URL</code> field.
   partial interface Navigator {
     [SameObject] readonly attribute USB usb;
   };
+
+  [Exposed=(DedicatedWorker,SharedWorker), SecureContext]
+  partial interface WorkerNavigator {
+    [SameObject] readonly attribute USB usb;
+  };
 </pre>
 
 <div class="example">
@@ -1612,18 +1617,6 @@ defined as follows:
   <dt><a>permission request algorithm</a></dt>
   <dd><a>Request the "usb" permission</a>.</dd>
 </dl>
-
-## Web Workers ## {#web-workers}
-
-The web [[workers]] API provides a method for running scripts in the background
-independently of user interface scripts.
-
-<pre class="idl">
-  [Exposed=(DedicatedWorker,SharedWorker), SecureContext]
-  partial interface WorkerNavigator {
-    [SameObject] readonly attribute USB usb;
-  };
-</pre>
 
 # Terminology # {#terminology}
 

--- a/index.bs
+++ b/index.bs
@@ -6,6 +6,7 @@ Shortname: webusb
 Level: 1
 Editor: Reilly Grant, Google Inc., reillyg@google.com
 Editor: Ken Rockot, Google Inc., rockot@google.com
+Editor: Ovidio Henriquez, Google Inc., odejesush@google.com
 Abstract: This document describes an API for securely providing access to Universal Serial Bus devices from web pages.
 Group: wicg
 Repository: https://github.com/WICG/webusb/
@@ -429,7 +430,7 @@ scheme, is encoded in the <code>URL</code> field.
     attribute EventHandler onconnect;
     attribute EventHandler ondisconnect;
     Promise&lt;sequence&lt;USBDevice>> getDevices();
-    Promise&lt;USBDevice> requestDevice(USBDeviceRequestOptions options);
+    [Exposed=Window] Promise&lt;USBDevice> requestDevice(USBDeviceRequestOptions options);
   };
 
   [SecureContext]
@@ -1610,6 +1611,22 @@ defined as follows:
   <dt><a>permission request algorithm</a></dt>
   <dd><a>Request the "usb" permission</a>.</dd>
 </dl>
+
+## Web Workers ## {#web-workers}
+
+The web [[workers]] API provides a method for running scripts in the background
+independently of user interface scripts. Web workers run scripts in their own
+separate worker context. Within this context, there is a {{WorkerNavigator}}
+interface that is analogous to the {{Navigator}} interface in the window
+context. Since web workers run scripts in the background, they should not be
+allowed to request a device.
+
+<pre class="idl">
+  [Exposed=Worker, SecureContext]
+  partial interface WorkerNavigator {
+    [SameObject] readonly attribute USB usb;
+  };
+</pre>
 
 # Terminology # {#terminology}
 


### PR DESCRIPTION
This change to the spec will allow the WebUSB interface to be accessible within the context of a Web Worker.

I created an [explainer](https://github.com/odejesush/webusb-on-workers/blob/master/EXPLAINER.md) document for this addition.

Additionally, this feature was mentioned before in issue [WebUSB#73](https://github.com/WICG/webusb/issues/73).

I checked if the change to the IDL in chromium compiled successfully in change [1014196](https://chromium-review.googlesource.com/c/chromium/src/+/1014196).

Feedback on the change is welcome :)