### PR TITLE
Mark additional interfaces with [SecureContext]

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -691,7 +691,8 @@ dictionary USBConnectionEventInit : EventInit {
 
 [
   Constructor(DOMString type, USBConnectionEventInit eventInitDict),
-  Exposed=(DedicatedWorker,SharedWorker,Window)
+  Exposed=(DedicatedWorker,SharedWorker,Window),
+  SecureContext
 ]
 interface USBConnectionEvent : Event {
   [SameObject] readonly attribute USBDevice device;
@@ -735,7 +736,7 @@ host it MUST perform the following steps for each script execution environment:
 # Device Usage # {#device-usage}
 
 <pre class="idl">
-  [Exposed=(DedicatedWorker,SharedWorker,Window)]
+  [Exposed=(DedicatedWorker,SharedWorker,Window), SecureContext]
   interface USBDevice {
     readonly attribute octet usbVersionMajor;
     readonly attribute octet usbVersionMinor;
@@ -1295,7 +1296,8 @@ What configuration is the device in after it resets?
 
   [
     Constructor(USBTransferStatus status, optional DataView? data),
-    Exposed=(DedicatedWorker,SharedWorker,Window)
+    Exposed=(DedicatedWorker,SharedWorker,Window),
+    SecureContext
   ]
   interface USBInTransferResult {
     readonly attribute DataView? data;
@@ -1304,7 +1306,8 @@ What configuration is the device in after it resets?
 
   [
     Constructor(USBTransferStatus status, optional unsigned long bytesWritten = 0),
-    Exposed=(DedicatedWorker,SharedWorker,Window)
+    Exposed=(DedicatedWorker,SharedWorker,Window),
+    SecureContext
   ]
   interface USBOutTransferResult {
     readonly attribute unsigned long bytesWritten;
@@ -1313,7 +1316,8 @@ What configuration is the device in after it resets?
 
   [
     Constructor(USBTransferStatus status, optional DataView? data),
-    Exposed=(DedicatedWorker,SharedWorker,Window)
+    Exposed=(DedicatedWorker,SharedWorker,Window),
+    SecureContext
   ]
   interface USBIsochronousInTransferPacket {
     readonly attribute DataView? data;
@@ -1322,7 +1326,8 @@ What configuration is the device in after it resets?
 
   [
     Constructor(sequence&lt;USBIsochronousInTransferPacket> packets, optional DataView? data),
-    Exposed=(DedicatedWorker,SharedWorker,Window)
+    Exposed=(DedicatedWorker,SharedWorker,Window),
+    SecureContext
   ]
   interface USBIsochronousInTransferResult {
     readonly attribute DataView? data;
@@ -1331,7 +1336,8 @@ What configuration is the device in after it resets?
 
   [
     Constructor(USBTransferStatus status, optional unsigned long bytesWritten = 0),
-    Exposed=(DedicatedWorker,SharedWorker,Window)
+    Exposed=(DedicatedWorker,SharedWorker,Window),
+    SecureContext
   ]
   interface USBIsochronousOutTransferPacket {
     readonly attribute unsigned long bytesWritten;
@@ -1340,7 +1346,8 @@ What configuration is the device in after it resets?
 
   [
     Constructor(sequence&lt;USBIsochronousOutTransferPacket> packets),
-    Exposed=(DedicatedWorker,SharedWorker,Window)
+    Exposed=(DedicatedWorker,SharedWorker,Window),
+    SecureContext
   ]
   interface USBIsochronousOutTransferResult {
     readonly attribute FrozenArray&lt;USBIsochronousOutTransferPacket> packets;
@@ -1420,7 +1427,8 @@ perform the following steps:
 <pre class="idl">
   [
     Constructor(USBDevice device, octet configurationValue),
-    Exposed=(DedicatedWorker,SharedWorker,Window)
+    Exposed=(DedicatedWorker,SharedWorker,Window),
+    SecureContext
   ]
   interface USBConfiguration {
     readonly attribute octet configurationValue;
@@ -1452,7 +1460,8 @@ Include some non-normative information about device configurations.
 <pre class="idl">
   [
     Constructor(USBConfiguration configuration, octet interfaceNumber),
-    Exposed=(DedicatedWorker,SharedWorker,Window)
+    Exposed=(DedicatedWorker,SharedWorker,Window),
+    SecureContext
   ]
   interface USBInterface {
     readonly attribute octet interfaceNumber;
@@ -1463,7 +1472,8 @@ Include some non-normative information about device configurations.
 
   [
     Constructor(USBInterface deviceInterface, octet alternateSetting),
-    Exposed=(DedicatedWorker,SharedWorker,Window)
+    Exposed=(DedicatedWorker,SharedWorker,Window),
+    SecureContext
   ]
   interface USBAlternateInterface {
     readonly attribute octet alternateSetting;
@@ -1548,7 +1558,8 @@ device.
 
   [
     Constructor(USBAlternateInterface alternate, octet endpointNumber, USBDirection direction),
-    Exposed=(DedicatedWorker,SharedWorker,Window)
+    Exposed=(DedicatedWorker,SharedWorker,Window),
+    SecureContext
   ]
   interface USBEndpoint {
     readonly attribute octet endpointNumber;


### PR DESCRIPTION
This change marks the rest of the interfaces exposed by WebUSB with the
[SecureContext] extended attribute so that they do not appear in
in-secure contexts. This is not strictly necessary since the partial
Navigator interface is the entry-point to this API but it prevents
developer confusion by making the API clearly unavailable.