### PR TITLE
Update editors for WebUSB specs

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4,9 +4,9 @@ Status: ED
 ED: https://wicg.github.io/webusb
 Shortname: webusb
 Level: 1
-Editor: Reilly Grant, Google Inc., reillyg@google.com
-Editor: Ken Rockot, Google Inc., rockot@google.com
-Editor: Ovidio Henriquez, Google Inc., odejesush@google.com
+Editor: Reilly Grant 83788, Google LLC https://www.google.com, reillyg@google.com
+Editor: Ken Rockot, Google LLC https://www.google.com, rockot@google.com
+Editor: Ovidio Henriquez, Google LLC https://www.google.com, odejesush@google.com
 Abstract: This document describes an API for securely providing access to Universal Serial Bus devices from web pages.
 Group: wicg
 Repository: https://github.com/WICG/webusb/

--- a/index.bs
+++ b/index.bs
@@ -5,8 +5,8 @@ ED: https://wicg.github.io/webusb
 Shortname: webusb
 Level: 1
 Editor: Reilly Grant 83788, Google LLC https://www.google.com, reillyg@google.com
-Editor: Ken Rockot, Google LLC https://www.google.com, rockot@google.com
-Editor: Ovidio Henriquez, Google LLC https://www.google.com, odejesush@google.com
+Editor: Ken Rockot 87080, Google LLC https://www.google.com, rockot@google.com
+Editor: Ovidio Henriquez 106543, Google LLC https://www.google.com, odejesush@google.com
 Abstract: This document describes an API for securely providing access to Universal Serial Bus devices from web pages.
 Group: wicg
 Repository: https://github.com/WICG/webusb/

--- a/test/index.bs
+++ b/test/index.bs
@@ -4,7 +4,7 @@ Status: ED
 ED: https://wicg.github.io/webusb/test/
 Shortname: webusb-test
 Level: 1
-Editor: Reilly Grant, Google Inc., reillyg@google.com
+Editor: Reilly Grant 83788, Google LLC https://www.google.com, reillyg@google.com
 Abstract: This document describes an API for testing a User Agent's implementation of the WebUSB API.
 Group: wicg
 Repository: https://github.com/WICG/webusb/


### PR DESCRIPTION
Google, Inc. is now Google LLC. Added editor ID for Reilly Grant.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/reillyeon/webusb/pull/144.html" title="Last updated on Aug 23, 2018, 8:14 PM GMT (ccaef54)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/webusb/144/0e1df1e...reillyeon:ccaef54.html" title="Last updated on Aug 23, 2018, 8:14 PM GMT (ccaef54)">Diff</a>