### PR TITLE
Update pre blocks to be xmp

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -419,7 +419,7 @@ scheme, is encoded in the <code>URL</code> field.
 
 # Device Enumeration # {#enumeration}
 
-<pre class="idl">
+<xmp class="idl">
   dictionary USBDeviceFilter {
     unsigned short vendorId;
     unsigned short productId;
@@ -430,15 +430,15 @@ scheme, is encoded in the <code>URL</code> field.
   };
 
   dictionary USBDeviceRequestOptions {
-    required sequence&lt;USBDeviceFilter> filters;
+    required sequence<USBDeviceFilter> filters;
   };
 
   [Exposed=(DedicatedWorker,SharedWorker,Window), SecureContext]
   interface USB : EventTarget {
     attribute EventHandler onconnect;
     attribute EventHandler ondisconnect;
-    Promise&lt;sequence&lt;USBDevice>> getDevices();
-    [Exposed=Window] Promise&lt;USBDevice> requestDevice(USBDeviceRequestOptions options);
+    Promise<sequence<USBDevice>> getDevices();
+    [Exposed=Window] Promise<USBDevice> requestDevice(USBDeviceRequestOptions options);
   };
 
   [Exposed=Window, SecureContext]
@@ -450,7 +450,7 @@ scheme, is encoded in the <code>URL</code> field.
   partial interface WorkerNavigator {
     [SameObject] readonly attribute USB usb;
   };
-</pre>
+</xmp>
 
 <div class="example">
 In this example, we retrieve some devices to include in a UI. When the page is
@@ -698,7 +698,7 @@ the UA MUST run the following steps:
 
 ## Events ## {#events}
 
-<pre class="idl">
+<xmp class="idl">
 dictionary USBConnectionEventInit : EventInit {
     required USBDevice device;
 };
@@ -711,7 +711,7 @@ dictionary USBConnectionEventInit : EventInit {
 interface USBConnectionEvent : Event {
   [SameObject] readonly attribute USBDevice device;
 };
-</pre>
+</xmp>
 
 When the UA detects a new <a>USB device</a> |device| connected to the host it
 MUST perform the following steps for each script execution environment:
@@ -749,7 +749,7 @@ host it MUST perform the following steps for each script execution environment:
 
 # Device Usage # {#device-usage}
 
-<pre class="idl">
+<xmp class="idl">
   [Exposed=(DedicatedWorker,SharedWorker,Window), SecureContext]
   interface USBDevice {
     readonly attribute octet usbVersionMajor;
@@ -767,24 +767,24 @@ host it MUST perform the following steps for each script execution environment:
     readonly attribute DOMString? productName;
     readonly attribute DOMString? serialNumber;
     readonly attribute USBConfiguration? configuration;
-    readonly attribute FrozenArray&lt;USBConfiguration> configurations;
+    readonly attribute FrozenArray<USBConfiguration> configurations;
     readonly attribute boolean opened;
-    Promise&lt;void> open();
-    Promise&lt;void> close();
-    Promise&lt;void> selectConfiguration(octet configurationValue);
-    Promise&lt;void> claimInterface(octet interfaceNumber);
-    Promise&lt;void> releaseInterface(octet interfaceNumber);
-    Promise&lt;void> selectAlternateInterface(octet interfaceNumber, octet alternateSetting);
-    Promise&lt;USBInTransferResult> controlTransferIn(USBControlTransferParameters setup, unsigned short length);
-    Promise&lt;USBOutTransferResult> controlTransferOut(USBControlTransferParameters setup, optional BufferSource data);
-    Promise&lt;void> clearHalt(USBDirection direction, octet endpointNumber);
-    Promise&lt;USBInTransferResult> transferIn(octet endpointNumber, unsigned long length);
-    Promise&lt;USBOutTransferResult> transferOut(octet endpointNumber, BufferSource data);
-    Promise&lt;USBIsochronousInTransferResult> isochronousTransferIn(octet endpointNumber, sequence&lt;unsigned long> packetLengths);
-    Promise&lt;USBIsochronousOutTransferResult> isochronousTransferOut(octet endpointNumber, BufferSource data, sequence&lt;unsigned long> packetLengths);
-    Promise&lt;void> reset();
+    Promise<void> open();
+    Promise<void> close();
+    Promise<void> selectConfiguration(octet configurationValue);
+    Promise<void> claimInterface(octet interfaceNumber);
+    Promise<void> releaseInterface(octet interfaceNumber);
+    Promise<void> selectAlternateInterface(octet interfaceNumber, octet alternateSetting);
+    Promise<USBInTransferResult> controlTransferIn(USBControlTransferParameters setup, unsigned short length);
+    Promise<USBOutTransferResult> controlTransferOut(USBControlTransferParameters setup, optional BufferSource data);
+    Promise<void> clearHalt(USBDirection direction, octet endpointNumber);
+    Promise<USBInTransferResult> transferIn(octet endpointNumber, unsigned long length);
+    Promise<USBOutTransferResult> transferOut(octet endpointNumber, BufferSource data);
+    Promise<USBIsochronousInTransferResult> isochronousTransferIn(octet endpointNumber, sequence<unsigned long> packetLengths);
+    Promise<USBIsochronousOutTransferResult> isochronousTransferOut(octet endpointNumber, BufferSource data, sequence<unsigned long> packetLengths);
+    Promise<void> reset();
   };
-</pre>
+</xmp>
 
 <div class="example">
 In this example we imagine a data logging device supporting up to 8 16-bit data
@@ -1280,7 +1280,7 @@ What configuration is the device in after it resets?
 
 ## Transfers ## {#transfers}
 
-<pre class="idl">
+<xmp class="idl">
   enum USBRequestType {
     "standard",
     "class",
@@ -1339,13 +1339,13 @@ What configuration is the device in after it resets?
   };
 
   [
-    Constructor(sequence&lt;USBIsochronousInTransferPacket> packets, optional DataView? data),
+    Constructor(sequence<USBIsochronousInTransferPacket> packets, optional DataView? data),
     Exposed=(DedicatedWorker,SharedWorker,Window),
     SecureContext
   ]
   interface USBIsochronousInTransferResult {
     readonly attribute DataView? data;
-    readonly attribute FrozenArray&lt;USBIsochronousInTransferPacket> packets;
+    readonly attribute FrozenArray<USBIsochronousInTransferPacket> packets;
   };
 
   [
@@ -1359,14 +1359,14 @@ What configuration is the device in after it resets?
   };
 
   [
-    Constructor(sequence&lt;USBIsochronousOutTransferPacket> packets),
+    Constructor(sequence<USBIsochronousOutTransferPacket> packets),
     Exposed=(DedicatedWorker,SharedWorker,Window),
     SecureContext
   ]
   interface USBIsochronousOutTransferResult {
-    readonly attribute FrozenArray&lt;USBIsochronousOutTransferPacket> packets;
+    readonly attribute FrozenArray<USBIsochronousOutTransferPacket> packets;
   };
-</pre>
+</xmp>
 
 A <dfn>control transfer</dfn> is a special class of USB traffic most commonly
 used for configuring a device. It consists of three stages:
@@ -1438,7 +1438,7 @@ perform the following steps:
 
 ## Configurations ## {#configurations}
 
-<pre class="idl">
+<xmp class="idl">
   [
     Constructor(USBDevice device, octet configurationValue),
     Exposed=(DedicatedWorker,SharedWorker,Window),
@@ -1447,9 +1447,9 @@ perform the following steps:
   interface USBConfiguration {
     readonly attribute octet configurationValue;
     readonly attribute DOMString? configurationName;
-    readonly attribute FrozenArray&lt;USBInterface> interfaces;
+    readonly attribute FrozenArray<USBInterface> interfaces;
   };
-</pre>
+</xmp>
 
 Each device configuration SHALL have a unique
 {{USBConfiguration/configurationValue}} that matches the
@@ -1471,7 +1471,7 @@ Include some non-normative information about device configurations.
 
 ## Interfaces ## {#interfaces}
 
-<pre class="idl">
+<xmp class="idl">
   [
     Constructor(USBConfiguration configuration, octet interfaceNumber),
     Exposed=(DedicatedWorker,SharedWorker,Window),
@@ -1480,7 +1480,7 @@ Include some non-normative information about device configurations.
   interface USBInterface {
     readonly attribute octet interfaceNumber;
     readonly attribute USBAlternateInterface alternate;
-    readonly attribute FrozenArray&lt;USBAlternateInterface> alternates;
+    readonly attribute FrozenArray<USBAlternateInterface> alternates;
     readonly attribute boolean claimed;
   };
 
@@ -1495,9 +1495,9 @@ Include some non-normative information about device configurations.
     readonly attribute octet interfaceSubclass;
     readonly attribute octet interfaceProtocol;
     readonly attribute DOMString? interfaceName;
-    readonly attribute FrozenArray&lt;USBEndpoint> endpoints;
+    readonly attribute FrozenArray<USBEndpoint> endpoints;
   };
-</pre>
+</xmp>
 
 Each interface provides a collection of {{USBInterface/alternates}} identified
 by a single <code>bInterfaceNumber</code> field found in their <a>interface
@@ -1558,7 +1558,7 @@ device.
 
 ## Endpoints ## {#endpoints}
 
-<pre class="idl">
+<xmp class="idl">
   enum USBDirection {
     "in",
     "out"
@@ -1581,7 +1581,7 @@ device.
     readonly attribute USBEndpointType type;
     readonly attribute unsigned long packetSize;
   };
-</pre>
+</xmp>
 
 Each endpoint within a particular device configuration SHALL have a unique
 combination of {{USBEndpoint/endpointNumber}} and {{USBEndpoint/direction}}.
@@ -1628,16 +1628,16 @@ defined as follows:
 <dl>
   <dt><a>permission descriptor type</a></dt>
   <dd>
-    <pre class="idl">
+    <xmp class="idl">
       dictionary USBPermissionDescriptor : PermissionDescriptor {
-        sequence&lt;USBDeviceFilter> filters;
+        sequence<USBDeviceFilter> filters;
       };
-    </pre>
+    </xmp>
   </dd>
   <dt><a>extra permission data type</a></dt>
   <dd>
     {{USBPermissionStorage}}, defined as:
-    <pre class="idl">
+    <xmp class="idl">
       dictionary AllowedUSBDevice {
         required octet vendorId;
         required octet productId;
@@ -1645,9 +1645,9 @@ defined as follows:
       };
 
       dictionary USBPermissionStorage {
-        sequence&lt;AllowedUSBDevice> allowedDevices = [];
+        sequence<AllowedUSBDevice> allowedDevices = [];
       };
-    </pre>
+    </xmp>
 
     {{AllowedUSBDevice}} instances have an internal slot
     <dfn attribute for="AllowedUSBDevice">\[[devices]]</dfn> that holds an
@@ -1655,11 +1655,11 @@ defined as follows:
   </dd>
   <dt><a>permission result type</a></dt>
   <dd>
-    <pre class="idl">
+    <xmp class="idl">
       interface USBPermissionResult : PermissionStatus {
-        attribute FrozenArray&lt;USBDevice> devices;
+        attribute FrozenArray<USBDevice> devices;
       };
-    </pre>
+    </xmp>
   </dd>
   <dt><a>permission query algorithm</a></dt>
   <dd>

--- a/test/index.bs
+++ b/test/index.bs
@@ -147,26 +147,26 @@ two benefits,
 
 # Global Testing Interface # {#test-interface}
 
-<pre class="idl">
+<xmp class="idl">
   partial interface USB {
     [SameObject] readonly attribute USBTest test;
   };
 
   interface USBDeviceRequestEvent : Event {
-    attribute FrozenArray&lt;USBDeviceFilter> filters;
+    attribute FrozenArray<USBDeviceFilter> filters;
 
-    void respondWith(Promise&lt;FakeUSBDevice> result);
+    void respondWith(Promise<FakeUSBDevice> result);
   };
 
   interface USBTest {
     attribute EventHandler onrequestdevice;
 
-    Promise&lt;void> initialize();
-    Promise&lt;void> attachToContext((HTMLIFrameElement or Worker) context);
+    Promise<void> initialize();
+    Promise<void> attachToContext((HTMLIFrameElement or Worker) context);
     FakeUSBDevice addFakeDevice(FakeUSBDeviceInit deviceInit);
-    Promise&lt;void> reset();
+    Promise<void> reset();
   };
-</pre>
+</xmp>
 
 By default, a UA SHALL NOT alter the behavior of a {{USB}} instance |usb| in any
 <a>global object</a> until it is reconfigured so that |usb| is <dfn>controlled
@@ -264,7 +264,7 @@ for tests to add simulated USB devices by calling {{USBTest/addFakeDevice()}}
 with an instance of {{FakeUSBDeviceInit}} containing the properties of the
 device to be added.
 
-<pre class="idl">
+<xmp class="idl">
   interface FakeUSBDevice : EventTarget {
     attribute EventHandler onclose;
 
@@ -287,18 +287,18 @@ device to be added.
     DOMString? productName;
     DOMString? serialNumber;
     octet activeConfigurationValue = 0;
-    sequence&lt;FakeUSBConfigurationInit> configurations;
+    sequence<FakeUSBConfigurationInit> configurations;
   };
 
   dictionary FakeUSBConfigurationInit {
     required octet configurationValue;
     DOMString? configurationName;
-    sequence&lt;FakeUSBInterfaceInit> interfaces;
+    sequence<FakeUSBInterfaceInit> interfaces;
   };
 
   dictionary FakeUSBInterfaceInit {
     required octet interfaceNumber;
-    sequence&lt;FakeUSBAlternateInterfaceInit> alternates;
+    sequence<FakeUSBAlternateInterfaceInit> alternates;
   };
 
   dictionary FakeUSBAlternateInterfaceInit {
@@ -307,7 +307,7 @@ device to be added.
     required octet interfaceSubclass;
     required octet interfaceProtocol;
     DOMString? interfaceName;
-    sequence&lt;FakeUSBEndpointInit> endpoints;
+    sequence<FakeUSBEndpointInit> endpoints;
   };
 
   dictionary FakeUSBEndpointInit {
@@ -316,7 +316,7 @@ device to be added.
     required USBEndpointType type;
     required unsigned long packetSize;
   };
-</pre>
+</xmp>
 
 When a {{USBDevice}} |device| is initialized from an fake USB device described
 by a {{FakeUSBDeviceInit}} |init| passed to {{USBTest/addFakeDevice()}} the


### PR DESCRIPTION
This change updates the &lt;pre> tags for IDL definitions to be &lt;xmp> tags so that characters don't need to be escaped.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/odejesush/webusb/pull/146.html" title="Last updated on Aug 24, 2018, 10:44 PM GMT (255c802)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/webusb/146/d7579c4...odejesush:255c802.html" title="Last updated on Aug 24, 2018, 10:44 PM GMT (255c802)">Diff</a>