### PR TITLE
Add a note about UUID endianness

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -277,6 +277,11 @@ The <code>iLandingPage</code> field, when non-zero, indicates a
 visit in order to control their device. The UA MAY suggest the user navigate
 to this URL when the device is connected.
 
+Note: The USB is a little-endian bus and so according to [[RFC4122]] the UUID
+above MUST be sent over the wire as the byte sequence <code>{0x38, 0xB6, 0x08,
+0x34, 0xA9, 0x09, 0xA0, 0x47, 0x8B, 0xFD, 0xA0, 0x76, 0x88, 0x15, 0xB6,
+0x65}</code>.
+
 ## WebUSB Device Requests ## {#device-requests}
 
 All <a>control transfers</a> defined by this specification are considered to
@@ -1793,6 +1798,12 @@ depending on what type of traffic is being sent.
 
 <pre class="biblio">
 {
+  "RFC4122": {
+    "href": "https://tools.ietf.org/html/rfc4122",
+    "title": "A Universally Unique IDentifier (UUID) URN Namespace",
+    "publisher": "Internet Engineering Task Force",
+    "date": "July 2005"
+  },
   "USB31": {
     "href": "http://www.usb.org/developers/docs/",
     "title": "Universal Serial Bus 3.1 Specification",


### PR DESCRIPTION
The rules for encoding UUIDs in little-endian are esoteric and so this change adds a note with the correct formatting.

This resolves issue #115.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/reillyeon/webusb/pull/151.html" title="Last updated on Nov 9, 2018, 11:50 PM GMT (4cb7450)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/webusb/151/1ffc266...reillyeon:4cb7450.html" title="Last updated on Nov 9, 2018, 11:50 PM GMT (4cb7450)">Diff</a>