### PR TITLE
Fix InvalidStateError condition for claimInterface

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -963,7 +963,7 @@ return a new {{Promise}} and run the following steps <a>in parallel</a>:
      <code>bInterfaceNumber</code> equal to |interfaceNumber|. If no such
      interface exists, <a>reject</a> |promise| with a {{NotFoundError}} and
      abort these steps.
-  3. If <code>|device|.{{USBDevice/opened}}</code> is not <code>true</code> and
+  3. If <code>|device|.{{USBDevice/opened}}</code> is not <code>true</code> or
      <code>|interface|.{{USBInterface/claimed}}</code> is not <code>false</code>,
      <a>reject</a> |promise| with an {{InvalidStateError}} and abort these
      steps.


### PR DESCRIPTION
The current text seems like a typo.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dsanders11/webusb-1/pull/160.html" title="Last updated on Dec 19, 2018, 8:04 PM UTC (4d3307a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/webusb/160/8442eb1...dsanders11:4d3307a.html" title="Last updated on Dec 19, 2018, 8:04 PM UTC (4d3307a)">Diff</a>