### PR TITLE
Migrate to references exported from the WebIDL spec

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -627,9 +627,8 @@ The {{USB/requestDevice()}} method, when invoked, MUST run the following steps:
        }
      </pre>
      Let |permissionResult| be the resulting {{Promise}}.
-  2. Return the result of <a>transforming</a> |permissionResult| with a
-     fullfillment handler that takes an argument |result| and runs the following
-     steps:
+  2. <a>Upon fulfillment</a> of |permissionResult| with |result| run the
+     following steps:
        1. If <code>|result|.{{USBPermissionResult/devices}}</code> is empty,
           throw a {{NotFoundError}} and abort these steps.
        2. Return <code>|result|.{{USBPermissionResult/devices}}[0]</code>.
@@ -1829,7 +1828,7 @@ spec: html
         text: triggered by user activation
         text: in parallel
         text: incumbent settings object
-spec: promises-guide-1
+spec: webidl
     type: dfn
         text: resolve
 </pre>

--- a/test/index.bs
+++ b/test/index.bs
@@ -414,5 +414,5 @@ spec: ECMAScript; urlPrefix: https://tc39.github.io/ecma262/#
 
 <pre class="link-defaults">
 spec:html; type:dfn; for:/; text:global object
-spec:promises-guide-1; type:dfn; text:resolve
+spec:webidl; type:dfn; text:resolve
 </pre>


### PR DESCRIPTION
Algorithms for working with Promises have moved from [promises-guide] to [WebIDL].


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/reillyeon/webusb/pull/175.html" title="Last updated on Sep 30, 2019, 5:41 PM UTC (fdf4ab1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/webusb/175/ab08225...reillyeon:fdf4ab1.html" title="Last updated on Sep 30, 2019, 5:41 PM UTC (fdf4ab1)">Diff</a>