### PR TITLE
Update language for User Activation v2

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -487,9 +487,9 @@ order to keep the interface up-to-date,
 
 If this is the first time the user has visited the page then it won't have
 permission to access any devices so the page must first call
-{{USB/requestDevice()}} in response to a user gesture. In this case the page
-supports devices from vendor <code>0xABCD</code> that carry the vendor-specific
-subclass <code>0x01</code>,
+{{USB/requestDevice()}} while the [=relevant global object=] has a
+<a>transient activation</a>. In this case the page supports devices from vendor
+<code>0xABCD</code> that carry the vendor-specific subclass <code>0x01</code>,
 
 <pre highlight="js">
   let button = document.getElementById('request-device');
@@ -642,8 +642,9 @@ steps <a>in parallel</a>:
      <code>|options|.{{USBPermissionDescriptor/filters}}</code> if |filter|
      <a>is not a valid filter</a> <a>reject</a> |promise| with a {{TypeError}}
      and abort these steps.
-  2. If the algorithm is not <a>triggered by user activation</a>, <a>reject</a>
-     |promise| with a {{SecurityError}} and abort these steps.
+  2. Check that the algorithm was triggered while the [=relevant global object=]
+     had a <a>transient activation</a>. Otherwise, <a>reject</a> |promise| with
+     a {{SecurityError}} and abort these steps.
   3. Set <code>|status|.{{PermissionStatus/state}}</code> to `"ask"`.
   4. <a>Enumerate all devices attached to the system</a>. Let this result be
      |enumerationResult|.
@@ -1825,7 +1826,7 @@ spec: Feature Policy; urlPrefix: https://wicg.github.io/feature-policy/#
 <pre class="link-defaults">
 spec: html
     type: dfn
-        text: triggered by user activation
+        text: transient activation
         text: in parallel
         text: incumbent settings object
 spec: webidl


### PR DESCRIPTION
This change updates references to "user gesture" to use the new language
used for User Activation v2. The new language now states that the
requestDevice algorithm has to be triggered while its relevant global
object has a transient activation.

This fixes #178.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/odejesush/webusb/pull/179.html" title="Last updated on Feb 11, 2020, 8:43 PM UTC (4dabd91)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/webusb/179/6400555...odejesush:4dabd91.html" title="Last updated on Feb 11, 2020, 8:43 PM UTC (4dabd91)">Diff</a>