### PR TITLE
Use correct Status

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1,6 +1,6 @@
 <pre class="metadata">
 Title: WebUSB API
-Status: CG-DRAFT
+Status: w3c/CG-DRAFT
 ED: https://wicg.github.io/webusb
 Shortname: webusb
 Level: 1

--- a/test/index.bs
+++ b/test/index.bs
@@ -5,7 +5,7 @@ ED: https://wicg.github.io/webusb/test/
 Shortname: webusb-test
 Level: 1
 Editor: Reilly Grant 83788, Google LLC https://www.google.com, reillyg@google.com
-Editor: Ovidio Henriquez 106543, Google LLC https://www.google.com, odejesush@google.com
+Editor: Ovidio Ruiz-Henríquez 106543, Google LLC https://www.google.com, odejesush@google.com
 Abstract: This document describes an API for testing a User Agent's implementation of the WebUSB API.
 Group: wicg
 Repository: https://github.com/WICG/webusb/

--- a/test/index.bs
+++ b/test/index.bs
@@ -1,6 +1,6 @@
 <pre class="metadata">
 Title: WebUSB Testing API
-Status: ED
+Status: w3c/CG-DRAFT
 ED: https://wicg.github.io/webusb/test/
 Shortname: webusb-test
 Level: 1


### PR DESCRIPTION
This change updates the `Status` line to be `w3c/CG-DRAFT`. This fixes the
Travis CI build.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/odejesush/webusb/pull/182.html" title="Last updated on Feb 21, 2020, 5:52 PM UTC (c471a26)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/webusb/182/667004f...odejesush:c471a26.html" title="Last updated on Feb 21, 2020, 5:52 PM UTC (c471a26)">Diff</a>