### PR TITLE
Rename Feature Policy to Permissions Policy

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1609,7 +1609,7 @@ of the SuperSpeed Endpoint Companion descriptor.
 
 # Integrations # {#integrations}
 
-## Permissions Policy ## {#permissions-policy}
+<h3 id="permissions-policy" oldids="feature-policy">Permissions Policy</h3>
 
 This specification defines a <a>policy-controlled feature</a>, identified by the
 token <code>"usb"</code>, that controls whether the {{Navigator/usb}} attribute

--- a/index.bs
+++ b/index.bs
@@ -178,7 +178,7 @@ who could take advantage of this new capability.
 
 After considering these options the authors have decided that the permission
 prompt encouraged by the {{USB/requestDevice()}} method and the integration with
-[[#feature-policy]] provide adequate protection against unwanted access to a
+[[#permissions-policy]] provide adequate protection against unwanted access to a
 device.
 
 ## Attacking the Host ## {#attacking-the-host}
@@ -1609,12 +1609,11 @@ of the SuperSpeed Endpoint Companion descriptor.
 
 # Integrations # {#integrations}
 
-## Feature Policy ## {#feature-policy}
+## Permissions Policy ## {#permissions-policy}
 
-This specification defines a <a>feature</a> that controls whether the
-{{Navigator/usb}} attribute is exposed on the {{Navigator}} object.
-
-The <a>feature name</a> for this feature is <code>"usb"</code>.
+This specification defines a <a>policy-controlled feature</a>, identified by the
+token <code>"usb"</code>, that controls whether the {{Navigator/usb}} attribute
+is exposed on the {{Navigator}} object.
 
 The <a>default allowlist</a> for this feature is <code>["self"]</code>.
 
@@ -1816,11 +1815,6 @@ spec: ECMAScript; urlPrefix: https://tc39.github.io/ecma262/#
         text: Array; url: sec-array-objects
         text: Promise; url:sec-promise-objects
         text: TypeError; url: sec-native-error-types-used-in-this-standard-typeerror
-spec: Feature Policy; urlPrefix: https://wicg.github.io/feature-policy/#
-    type: dfn
-        text: default allowlist
-        text: feature
-        text: feature name
 </pre>
 
 <pre class="link-defaults">


### PR DESCRIPTION
Feature Policy has been renamed, and the spec has moved. This change
updates the integration to point to the new locations, and to use the
new name.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/clelland/webusb/pull/192.html" title="Last updated on Oct 21, 2020, 1:40 PM UTC (fac6087)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/webusb/192/d0f7159...clelland:fac6087.html" title="Last updated on Oct 21, 2020, 1:40 PM UTC (fac6087)">Diff</a>