### PR TITLE
Fix missing device target object in claimInterface

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -957,7 +957,8 @@ parallel:
 The {{USBDevice/claimInterface(interfaceNumber)}} method, when invoked, MUST
 return a new {{Promise}} |promise| and run the following steps <a>in
 parallel</a>:
-
+  
+  1. Let |device| be the target {{USBDevice}} object.
   1. If the device is no longer connected to the system, <a>reject</a> |promise|
      with a {{NotFoundError}} and abort these steps.
   1. Let |interface| be the interface in the <a>active configuration</a> with

--- a/index.bs
+++ b/index.bs
@@ -959,7 +959,7 @@ return a new {{Promise}} |promise| and run the following steps <a>in
 parallel</a>:
   
   1. Let |device| be the target {{USBDevice}} object.
-  1. If the device is no longer connected to the system, <a>reject</a> |promise|
+  1. If |device| is no longer connected to the system, <a>reject</a> |promise|
      with a {{NotFoundError}} and abort these steps.
   1. Let |interface| be the interface in the <a>active configuration</a> with
      <code>bInterfaceNumber</code> equal to |interfaceNumber|. If no such


### PR DESCRIPTION
Adds the `1. Let device be the target USBDevice object.` step to claimInterface.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/littledivy/webusb-spec/pull/202.html" title="Last updated on Sep 8, 2021, 10:33 PM UTC (ec2f91b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/webusb/202/55d24aa...littledivy:ec2f91b.html" title="Last updated on Sep 8, 2021, 10:33 PM UTC (ec2f91b)">Diff</a>