### PR TITLE
Add default value to exclusionFilters

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -452,7 +452,7 @@ scheme, is encoded in the <code>URL</code> field.
 
   dictionary USBDeviceRequestOptions {
     required sequence<USBDeviceFilter> filters;
-    sequence<USBDeviceFilter> exclusionFilters;
+    sequence<USBDeviceFilter> exclusionFilters = [];
   };
 
   [Exposed=(Worker,Window), SecureContext]
@@ -666,15 +666,10 @@ steps <a>in parallel</a>:
      <code>|options|.{{USBPermissionDescriptor/filters}}</code> if |filter|
      <a>is not a valid filter</a> <a>reject</a> |promise| with a {{TypeError}}
      and abort these steps.
-  2. If <code>|options|.{{USBPermissionDescriptor/exclusionFilters}}</code> is
-     present, then run the following steps:
-       1. If <code>|options|.{{USBPermissionDescriptor/exclusionFilters}}</code>
-          is empty, then <a>reject</a> |promise| with a {{TypeError}}
-          and abort these steps.
-       2. For each |exclusionFilter| in
-          <code>|options|.{{USBPermissionDescriptor/exclusionFilters}}</code> if
-          |exclusionFilter| <a>is not a valid filter</a> <a>reject</a> |promise|
-          with a {{TypeError}} and abort these steps.
+  2. For each |exclusionFilter| in
+    <code>|options|.{{USBPermissionDescriptor/exclusionFilters}}</code> if
+    |exclusionFilter| <a>is not a valid filter</a> <a>reject</a> |promise|
+    with a {{TypeError}} and abort these steps.
   3. Check that the algorithm was triggered while the [=relevant global object=]
      had a <a>transient activation</a>. Otherwise, <a>reject</a> |promise| with
      a {{SecurityError}} and abort these steps.
@@ -683,7 +678,9 @@ steps <a>in parallel</a>:
      |enumerationResult|.
   6. Remove devices from |enumerationResult| if they do not <a>match a device
      filter</a> in <code>|options|.{{USBPermissionDescriptor/filters}}</code>.
-  7. Remove devices from |enumerationResult| if they <a>match a device filter</a>
+  7. If <code>|options|.{{USBPermissionDescriptor/exclusionFilters}}</code> is
+     not empty, remove devices from |enumerationResult| if they <a>match a
+     device filter</a>
      in <code>|options|.{{USBPermissionDescriptor/exclusionFilters}}</code>.
   8. Display a prompt to the user requesting they select a device from
      |enumerationResult|. The UA SHOULD show a human-readable name for each
@@ -2390,7 +2387,7 @@ defined as follows:
               <code>|desc|.{{USBPermissionDescriptor/filters}}</code>, continue
               to the next |device|.
            2. If <code>|desc|.{{USBPermissionDescriptor/exclusionFilters}}</code>
-              is set and |device| <a>matches a device filter</a> in
+              is not empty and |device| <a>matches a device filter</a> in
               <code>|desc|.{{USBPermissionDescriptor/exclusionFilters}}</code>,
               continue to the next |device|.
            3. Get the {{USBDevice}} representing |device| and add it to

--- a/index.bs
+++ b/index.bs
@@ -678,9 +678,7 @@ steps <a>in parallel</a>:
      |enumerationResult|.
   6. Remove devices from |enumerationResult| if they do not <a>match a device
      filter</a> in <code>|options|.{{USBPermissionDescriptor/filters}}</code>.
-  7. If <code>|options|.{{USBPermissionDescriptor/exclusionFilters}}</code> is
-     not empty, remove devices from |enumerationResult| if they <a>match a
-     device filter</a>
+  7. Remove devices from |enumerationResult| if they <a>match a device filter</a>
      in <code>|options|.{{USBPermissionDescriptor/exclusionFilters}}</code>.
   8. Display a prompt to the user requesting they select a device from
      |enumerationResult|. The UA SHOULD show a human-readable name for each
@@ -2387,7 +2385,7 @@ defined as follows:
               <code>|desc|.{{USBPermissionDescriptor/filters}}</code>, continue
               to the next |device|.
            2. If <code>|desc|.{{USBPermissionDescriptor/exclusionFilters}}</code>
-              is not empty and |device| <a>matches a device filter</a> in
+              is set and |device| <a>matches a device filter</a> in
               <code>|desc|.{{USBPermissionDescriptor/exclusionFilters}}</code>,
               continue to the next |device|.
            3. Get the {{USBDevice}} representing |device| and add it to


### PR DESCRIPTION
As suggested in https://chromium-review.googlesource.com/c/chromium/src/+/4614682/15..16/third_party/blink/renderer/modules/webusb/usb.cc#b247, this PR sets the default value of `exclusionFilters` to `[]` to avoid differentiating between no list and an empty list.

@reillyeon please review.

Related to https://github.com/WICG/webusb/pull/233 and https://github.com/WICG/webusb/issues/232


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/beaufortfrancois/webusb/pull/235.html" title="Last updated on Jun 23, 2023, 7:25 AM UTC (3656ec2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/webusb/235/1ebe98c...beaufortfrancois:3656ec2.html" title="Last updated on Jun 23, 2023, 7:25 AM UTC (3656ec2)">Diff</a>