### PR TITLE
Add hubs to the protected interface class list

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2058,6 +2058,10 @@ of the following values.
     <td>Mass Storage</td>
   </tr>
   <tr>
+    <td><code>0x09</code></td>
+    <td>Hub</td>
+  </tr>
+  <tr>
     <td><code>0x0B</code></td>
     <td>Smart Card</td>
   </tr>


### PR DESCRIPTION
For practical purposes a hub interface will always be unclaimable because the OS will always have it's own hub driver attached to it. However for clarity and in case there's an OS that doesn't enforce this we might as well add hubs to the protected interface class list.

Fixed #263.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/webusb/pull/267.html" title="Last updated on May 19, 2026, 11:11 PM UTC (4ff4d8f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/webusb/267/1854321...4ff4d8f.html" title="Last updated on May 19, 2026, 11:11 PM UTC (4ff4d8f)">Diff</a>