### PR TITLE
Restrict control transfers to standard requests and protected classes

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1805,44 +1805,50 @@ given {{USBDevice}} |device|, {{USBControlTransferParameters}} |setup|, and
 1. If |configuration| is `null`, return `undefined`.
 1. If |setup|.{{USBControlTransferParameters/requestType}} is {{"standard"}},
     perform the following steps:
-    1. If |direction| is not {{"in"}}, return [=a promise rejected with=] a
+    1. If |direction| is {{"out"}}, return [=a promise rejected with=] a
         "{{SecurityError}}" {{DOMException}}.
     1. If |setup|.{{USBControlTransferParameters/request}} is not one of
         `0x00` (GET_STATUS), `0x06` (GET_DESCRIPTOR), `0x08` (GET_CONFIGURATION),
         `0x0A` (GET_INTERFACE) or `0x0C` (SYNCH_FRAME), return [=a promise
         rejected with=] a "{{SecurityError}}" {{DOMException}}.
-1. Let |interface| be `null`.
-1. If |setup|.{{USBControlTransferParameters/recipient}} is {{"interface"}} or
-    |setup|.{{USBControlTransferParameters/requestType}} is {{"class"}},
+1. If |setup|.{{USBControlTransferParameters/requestType}} is {{"class"}},
     perform the following steps:
     1. Let |interfaceNumber| be the lower 8 bits of
         |setup|.{{USBControlTransferParameters/index}}.
     1. Let |interfaceIndex| be the result of [=finding the interface index=]
         with |interfaceNumber| and |configuration|.
-    1. If |interfaceIndex| is not `-1`, set |interface| to
+    1. If |interfaceIndex| is not `-1`, perform the following steps:
+        1. Let |interface| be
+            |configuration|.{{USBConfiguration/[[interfaces]]}}[|interfaceIndex|].
+        1. If |interface|.{{USBInterface/[[isProtectedClass]]}} is `true`,
+            return [=a promise rejected with=] a "{{SecurityError}}"
+            {{DOMException}}.
+1. If |setup|.{{USBControlTransferParameters/recipient}} is {{"interface"}},
+    perform the following steps:
+    1. Let |interfaceNumber| be the lower 8 bits of
+        |setup|.{{USBControlTransferParameters/index}}.
+    1. Let |interfaceIndex| be the result of [=finding the interface index=]
+        with |interfaceNumber| and |configuration|.
+    1. If |interfaceIndex| is `-1`, return [=a promise rejected with=] a
+        "{{NotFoundError}}" {{DOMException}}.
+    1. Let |interface| be
         |configuration|.{{USBConfiguration/[[interfaces]]}}[|interfaceIndex|].
+    1. If |interface|.{{USBInterface/[[isProtectedClass]]}} is `true`, return [=a
+        promise rejected with=] a "{{SecurityError}}" {{DOMException}}.
+    1. If the result of [=finding if the interface is claimed=] with
+        |interface| is not `true`, return [=a promise rejected with=] an
+        "{{InvalidStateError}}" {{DOMException}}.
 1. If |setup|.{{USBControlTransferParameters/recipient}} is {{"endpoint"}},
     perform the following steps:
     1. Let |endpointAddress| be |setup|.{{USBControlTransferParameters/index}}.
     1. Let |endpoint| be the result of [=finding the endpoint=] with
         |endpointAddress| and |device|.
-    1. If |endpoint| is not `null`, perform the following steps:
-        1. Let |alternate| be |endpoint|.{{USBEndpoint/[[alternateInterface]]}}.
-        1. Set |interface| to |alternate|.{{USBAlternateInterface/[[interface]]}}.
-1. If |interface| is not `null` and
-    |interface|.{{USBInterface/[[isProtectedClass]]}} is `true`, return [=a
-    promise rejected with=] a "{{SecurityError}}" {{DOMException}}.
-1. If |setup|.{{USBControlTransferParameters/recipient}} is {{"interface"}},
-    perform the following steps:
-    1. If |interface| is `null`, return [=a promise rejected with=] a
+    1. If |endpoint| is `null`, return [=a promise rejected with=] a
         "{{NotFoundError}}" {{DOMException}}.
-    1. If the result of [=finding if the interface is claimed=] with
-        |interface| is not `true`, return [=a promise rejected with=] an
-        "{{InvalidStateError}}" {{DOMException}}.
-1. If |setup|.{{USBControlTransferParameters/recipient}} is {{"endpoint"}}, run
-    the following steps:
-    1. If |interface| is `null`, return [=a promise rejected with=] a
-        "{{NotFoundError}}" {{DOMException}}.
+    1. Let |alternate| be |endpoint|.{{USBEndpoint/[[alternateInterface]]}}.
+    1. Let |interface| be |alternate|.{{USBAlternateInterface/[[interface]]}}.
+    1. If |interface|.{{USBInterface/[[isProtectedClass]]}} is `true`, return [=a
+        promise rejected with=] a "{{SecurityError}}" {{DOMException}}.
     1. If the result of [=finding if the interface is claimed=] with |interface|
         is `false`, return [=a promise rejected with=] an
         "{{InvalidStateError}}" {{DOMException}}.
@@ -2817,6 +2823,7 @@ spec: html
 spec: webidl
     type: dfn
         text: resolve
+spec: permissions; type: enum-value; text: prompt
 spec:infra; type:dfn; text:list
 spec:infra; type:dfn; for:list; text:for each
 spec:infra; type:dfn; for:list; text:append

--- a/index.bs
+++ b/index.bs
@@ -2823,7 +2823,6 @@ spec: html
 spec: webidl
     type: dfn
         text: resolve
-spec: permissions; type: enum-value; text: prompt
 spec:infra; type:dfn; text:list
 spec:infra; type:dfn; for:list; text:for each
 spec:infra; type:dfn; for:list; text:append

--- a/index.bs
+++ b/index.bs
@@ -1476,8 +1476,8 @@ method, when invoked, MUST run the following steps:
 1. Let |global| be [=this=]'s [=relevant global object=].
 1. If [=check if the device is configured=] with [=this=] returns a
     {{Promise}}, return that value.
-1. If [=check the validity of the control transfer parameters=] with [=this=]
-    and |setup| returns a {{Promise}}, return that value.
+1. If [=check the validity of the control transfer parameters=] with [=this=],
+    |setup|, and {{"in"}} returns a {{Promise}}, return that value.
 1. Let |promise| be [=a new promise=].
 1. Run the following steps [=in parallel=].
     1. If |length| is greater than 0, let |buffer| be a host buffer with space
@@ -1515,8 +1515,8 @@ method, when invoked, MUST run the following steps:
 1. Let |global| be [=this=]'s [=relevant global object=].
 1. If [=check if the device is configured=] with [=this=] returns a
     {{Promise}}, return that value.
-1. If [=check the validity of the control transfer parameters=] with [=this=]
-    and |setup| returns a {{Promise}}, return that value.
+1. If [=check the validity of the control transfer parameters=] with [=this=],
+    |setup|, and {{"out"}} returns a {{Promise}}, return that value.
 1. [=Get a copy of the buffer source=] |data| and let the result be |bytes|.
 1. Let |promise| be [=a new promise=].
 1. Run the following steps [=in parallel=].
@@ -1797,34 +1797,52 @@ Issue(36): What configuration is the device in after it resets?
 
 <div algorithm="check the validity of the control transfer parameters">
 To <dfn>check the validity of the control transfer parameters</dfn> with the
-given {{USBDevice}} |device| and {{USBControlTransferParameters}} |setup|,
-perform the following steps:
+given {{USBDevice}} |device|, {{USBControlTransferParameters}} |setup|, and
+{{USBDirection}} |direction|, perform the following steps:
 
 1. Let |configuration| be the result of [=finding the current configuration=]
     with |device|.
 1. If |configuration| is `null`, return `undefined`.
-1. If |setup|.{{USBControlTransferParameters/recipient}} is {{"interface"}},
+1. If |setup|.{{USBControlTransferParameters/requestType}} is {{"standard"}},
+    perform the following steps:
+    1. If |direction| is not {{"in"}}, return [=a promise rejected with=] a
+        "{{SecurityError}}" {{DOMException}}.
+    1. If |setup|.{{USBControlTransferParameters/request}} is not one of
+        `0x00` (GET_STATUS), `0x06` (GET_DESCRIPTOR), `0x08` (GET_CONFIGURATION),
+        `0x0A` (GET_INTERFACE) or `0x0C` (SYNCH_FRAME), return [=a promise
+        rejected with=] a "{{SecurityError}}" {{DOMException}}.
+1. Let |interface| be `null`.
+1. If |setup|.{{USBControlTransferParameters/recipient}} is {{"interface"}} or
+    |setup|.{{USBControlTransferParameters/requestType}} is {{"class"}},
     perform the following steps:
     1. Let |interfaceNumber| be the lower 8 bits of
         |setup|.{{USBControlTransferParameters/index}}.
     1. Let |interfaceIndex| be the result of [=finding the interface index=]
         with |interfaceNumber| and |configuration|.
-    1. If |interfaceIndex| is equal to `-1`, return [=a promise rejected with=]
-        a "{{NotFoundError}}" {{DOMException}}.
-    1. Let |interface| be
+    1. If |interfaceIndex| is not `-1`, set |interface| to
         |configuration|.{{USBConfiguration/[[interfaces]]}}[|interfaceIndex|].
+1. If |setup|.{{USBControlTransferParameters/recipient}} is {{"endpoint"}},
+    perform the following steps:
+    1. Let |endpointAddress| be |setup|.{{USBControlTransferParameters/index}}.
+    1. Let |endpoint| be the result of [=finding the endpoint=] with
+        |endpointAddress| and |device|.
+    1. If |endpoint| is not `null`, perform the following steps:
+        1. Let |alternate| be |endpoint|.{{USBEndpoint/[[alternateInterface]]}}.
+        1. Set |interface| to |alternate|.{{USBAlternateInterface/[[interface]]}}.
+1. If |interface| is not `null` and
+    |interface|.{{USBInterface/[[isProtectedClass]]}} is `true`, return [=a
+    promise rejected with=] a "{{SecurityError}}" {{DOMException}}.
+1. If |setup|.{{USBControlTransferParameters/recipient}} is {{"interface"}},
+    perform the following steps:
+    1. If |interface| is `null`, return [=a promise rejected with=] a
+        "{{NotFoundError}}" {{DOMException}}.
     1. If the result of [=finding if the interface is claimed=] with
         |interface| is not `true`, return [=a promise rejected with=] an
         "{{InvalidStateError}}" {{DOMException}}.
 1. If |setup|.{{USBControlTransferParameters/recipient}} is {{"endpoint"}}, run
     the following steps:
-    1. Let |endpointAddress| be |setup|.{{USBControlTransferParameters/index}}.
-    1. Let |endpoint| be the result of [=finding the endpoint=] with
-        |endpointAddress| and |device|.
-    1. If |endpoint| is `null`, return [=a promise rejected with=] a
+    1. If |interface| is `null`, return [=a promise rejected with=] a
         "{{NotFoundError}}" {{DOMException}}.
-    1. Let |alternate| be |endpoint|.{{USBEndpoint/[[alternateInterface]]}}.
-    1. Let |interface| be |alternate|.{{USBAlternateInterface/[[interface]]}}.
     1. If the result of [=finding if the interface is claimed=] with |interface|
         is `false`, return [=a promise rejected with=] an
         "{{InvalidStateError}}" {{DOMException}}.


### PR DESCRIPTION
This change aligns the specification with recent security improvements in Chromium. It introduces an allowlist for standard control requests and ensures that transfers targeting protected interface classes are blocked, even when using non-interface recipients.

This will close [#268](https://github.com/WICG/webusb/issues/268)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/alvinjiooo/webusb/pull/270.html" title="Last updated on Jun 4, 2026, 8:08 PM UTC (ef9af36)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/webusb/270/337426a...alvinjiooo:ef9af36.html" title="Last updated on Jun 4, 2026, 8:08 PM UTC (ef9af36)">Diff</a>